### PR TITLE
feat: hydrate contributors

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,46 +155,8 @@
   <section class="contributors">
     <div class="centered-content">
       <h2 style="text-align:center;font-size:2.2rem;font-weight:900;margin-bottom:2.2rem;">Contributors</h2>
-      <div class="core-row">
-        <a href="https://github.com/fraxken" target="_blank" class="core-avatar">
-          <img src="https://github.com/fraxken.png" alt="Thomas GENTILHOMME">
-          <div class="core-name">Thomas.G</div>
-        </a>
-        <a href="https://github.com/tony-go" target="_blank" class="core-avatar">
-          <img src="https://github.com/tony-go.png" alt="Tony Gorez">
-          <div class="core-name">Tony.G</div>
-        </a>
-        <a href="https://github.com/antoine-coulon" target="_blank" class="core-avatar">
-          <img src="https://github.com/antoine-coulon.png" alt="Antoine Coulon">
-          <div class="core-name">Antoine.C</div>
-        </a>
-        <a href="https://github.com/Kawacrepe" target="_blank" class="core-avatar">
-          <img src="https://github.com/Kawacrepe.png" alt="Vincent Dhennin">
-          <div class="core-name">Vincent.D</div>
-        </a>
-        <a href="https://github.com/im-codebreaker" target="_blank" class="core-avatar">
-          <img src="https://github.com/im-codebreaker.png" alt="Mehdi Bouchard">
-          <div class="core-name">Mehdi.B</div>
-        </a>
-        <a href="https://github.com/PierreDemailly" target="_blank" class="core-avatar">
-          <img src="https://github.com/PierreDemailly.png" alt="Pierre Demailly">
-          <div class="core-name">Pierre</div>
-        </a>
-      </div>
-      <div class="contributors-row">
-        <a href="https://github.com/Rossb0b" target="_blank" class="contributor-avatar">
-          <img src="https://github.com/Rossb0b.png" alt="Nicolas Hallaert">
-          <div class="contributor-name">Nicolas</div>
-        </a>
-        <a href="https://clementgombauld.netlify.app/" target="_blank" class="contributor-avatar">
-          <img src="https://github.com/clemgbld.png" alt="Clément GOMBAULD">
-          <div class="contributor-name">Clément</div>
-        </a>
-        <a href="https://github.com/fabnguess" target="_blank" class="contributor-avatar">
-          <img src="https://github.com/fabnguess.png" alt="Kouadio Fabrice N'guessan">
-          <div class="contributor-name">Fabrice</div>
-        </a>
-      </div>
+      <div id="core-row"></div>
+      <div id="contributors-row"></div>
     </div>
   </section>
 
@@ -224,6 +186,7 @@
   </section>
 
   <script type="module" src="./src/particules.js"></script>
+  <script type="module" src="./src/hydrate-contributors.js"></script>
 </body>
 
 </html>

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -269,8 +269,8 @@ header>.header-content>.description b {
 }
 
 /* Contributors Section */
-.core-row,
-.contributors-row {
+#core-row,
+#contributors-row {
   display: flex;
   justify-content: center;
   gap: 2.5rem;

--- a/src/hydrate-contributors.js
+++ b/src/hydrate-contributors.js
@@ -1,0 +1,43 @@
+(async function hydrateContributorsIIFE() {
+  const coreRow = document.getElementById("core-row");
+  const commitersRow = document.getElementById("contributors-row");
+
+  const response = await fetch("https://raw.githubusercontent.com/NodeSecure/Governance/main/contributors.json");
+
+  if (!response.ok) {
+    throw new Error(`Error while fetching contributors list: ${response.status}`);
+  }
+
+  const contributors = await response.json();
+
+  for (const coreContributor of contributors.core) {
+    const contributorElement = createContributorElement(coreContributor, "core");
+    coreRow.appendChild(contributorElement);
+  }
+
+  for (const contributor of contributors.committers) {
+    const contributorElement = createContributorElement(contributor);
+    commitersRow.appendChild(contributorElement);
+  }
+}());
+
+function createContributorElement(data, type = "contributor") {
+  const cLink = document.createElement("a");
+
+  cLink.href = `https://github.com/${data.github}`;
+  cLink.target = "_blank";
+  cLink.className = `${type}-avatar`;
+
+  const img = document.createElement("img");
+  img.src = `https://github.com/${data.github}.png`;
+  img.alt = data.name;
+
+  const nameDiv = document.createElement("div");
+  nameDiv.className = `${type}-name`;
+  nameDiv.textContent = data.name;
+
+  cLink.appendChild(img);
+  cLink.appendChild(nameDiv);
+
+  return cLink;
+}


### PR DESCRIPTION
added script to import list of core and commiters contribuers from the gouvernance json file

_WARNING: The result is not exactly the same_

-  Names are slightly different compared to the current version due to data differences, eg. Thomas instead of Thomas.G
-  In this version all links redirecte to github pages (not always the case in current list)
- Nicolas is missing in the new list
